### PR TITLE
Add docker-compose and review README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,76 @@
 # ODR-DabMux-Generator
-[🢂 Click here to access the generator 🢀](https://lucasgallone.github.io/ODR-DabMux-Generator/)
 
+## Overview
 
-This is an HTML generator to easily create the configuration file of a DAB+ multiplex with all settings, including the services list, which can then run with the tools of Opendigitalradio.
+This is an HTML generator to easily create the configuration file of a DAB+
+multiplex with all settings, including the services list, which can then be used by `odr-dabmux` from Opendigitalradio.
 
-The purpose is to simplify the creation of the configuration file, to automate the assignment of the ECC and LIC values ​​by choosing the country and language of each of your services (Rather than looking for this information in the official ETSI documents).
+The purpose is to simplify the creation of the configuration file, to automate
+the assignment of the ECC and LIC values ​​by choosing the country and language
+of each of your services (Rather than looking for this information in the
+official ETSI documents).
 
-There is also a CUs calculator that runs in real-time and updates as you add your services, in order to be certain not to exceed the max Capacity Units value (864), and therefore to adapt the audio bitrate and the EEP protection of the services on a case-by-case basis, in order to remain within the standard.
+There is also a CUs calculator that runs in real-time and updates as you add
+your services, in order to be certain not to exceed the max Capacity Units
+value (864), and therefore to adapt the audio bitrate and the EEP protection
+of the services on a case-by-case basis, in order to remain within the standard.
 
-You can also import an existing configuration file in order to edit it. The only disadvantage is that the ECC and LIC values will be ignored since it is difficult to guess the exact country and language of the services just from the values. Therefore, you will have to add them manually from the interface before exporting your new configuration file.
+You can also import an existing configuration file in order to edit it. The
+only disadvantage is that the ECC and LIC values will be ignored since it is
+difficult to guess the exact country and language of the services just from
+the values. Therefore, you will have to add them manually from the interface
+before exporting your new configuration file.
 
-Once you have generated and downloaded your configuration file with your desired services list, place it in the config folder of ODR.
-<br>
+Once you have generated and downloaded your configuration file with your
+desired services list, place it in the config folder of ODR.
+
 Your multiplex should be ready to run now!
 
-[Click here to visit the original page of the ODR-DabMux project.](https://github.com/Opendigitalradio/ODR-DabMux)
+You have 2 ways of running the generator:
 
-# Fields that can be generated
+1. Remotely, via github:
 
-• ```Ensemble ID (EID)``` - Your multiplex identification code (4 characters max).
+[🢂 Click here to access the generator 🢀](https://lucasgallone.github.io/ODR-DabMux-Generator/)
 
+1. Locally, via a container:
 
-• ```Ensemble Country (for ECC)``` - Automatically generates the ECC (Extended Country Code) for your ensemble, associated to the selected country in the list. Select the country your multiplex is broadcasting from.
+```bash
+git clone https://github.com/lucasgallone/odr-dabmux-generator
+cd odr-dabmux-generator
+docker compose up --detach
 
+# Then access http://localhost
+```
 
-• ```Long Ensemble Label``` - The name of your multiplex that will be displayed on receivers (16 characters max).
+## Fields that can be generated
 
-
-• ```Short Ensemble Label``` - Same purpose as the previous field, but shorter (8 characters max), for the receivers with a limited display.
-
-
-• ```SID (Serivce ID)``` - The identification code of your radio service, equivalent to the PI code function on FM (4 characters max).
-
-
-• ```Long Label``` - The name of your radio service that will be displayed on receivers (16 characters max).
-
-
-• ```Short Label``` - Same purpose as the previous field, but shorter (8 characters max), for the receivers with a limited display.
-
-
-• ```PTY (Program Type)``` - A function that allows to know the program style broadcast by your radio service (e.g. Pop Music, Rock Music, News).
-
-
-• ```DAB Type``` - Must be modified only if you want to use Standard DAB (Still active in the UK), the default value is to create a DAB+ service.
-
-
-• ```Bitrate``` - The audio quality of your radio service, from 8 to 384 Kbps. The real-time CUs calculator might help you set the correct value.
-
-
-• ```EEP``` - (Equal Error Protection) - The lower the value is (1A), the easiest your radio service will be decoded by receivers with a weak signal, but it will increase the CUs usage in comparison to an higher value (2A, 3A or 4A). The real-time CUs calculator might help you set the correct value.
-
-
-• ```Country (for ECC)``` - Automatically generates the ECC (Extended Country Code) for your radio service, associated to the selected country in the list. Select the country the radio station is broadcasting from.
-
-
-• ```Language (for LIC)``` - Automatically generates the LIC (Language Identification Code) for your radio service, associated to the selected language in the list. Select the language used by the radio station.
-
-
-• ```Port``` - The port that will be used for the "inputuri" value of your radio service. Leave the default value unless you really want to use a customized one.
+| Field | Description |
+| ----- | ----------- |
+| Ensemble ID (EID) | Your multiplex identification code (4 characters max) |
+| Ensemble Country (for ECC) | Automatically generates the ECC (Extended Country Code) for your ensemble, associated to the selected country in the list. Select the country your multiplex is broadcasting from |
+| Long Ensemble Label | The name of your multiplex that will be displayed on receivers (16 characters max) |
+| Short Ensemble Label | Same purpose as the previous field, but shorter (8 characters max), for the receivers with a limited display |
+| SID (Serivce ID) | The identification code of your radio service, equivalent to the PI code function on FM (4 characters max) |
+| Long Label | The name of your radio service that will be displayed on receivers (16 characters max) |
+| Short Label | Same purpose as the previous field, but shorter (8 characters max), for the receivers with a limited display |
+| PTY (Program Type) | A function that allows to know the program style broadcast by your radio service (e.g. Pop Music, Rock Music, News) |
+| DAB Type | Must be modified only if you want to use Standard DAB (Still active in the UK), the default value is to create a DAB+ service |
+| Bitrate | The audio quality of your radio service, from 8 to 384 Kbps. The real-time CUs calculator might help you set the correct value |
+| EEP (Equal Error Protection) | The lower the value is (1A), the easiest your radio service will be decoded by receivers with a weak signal, but it will increase the CUs usage in comparison to an higher value (2A, 3A or 4A). The real-time CUs calculator might help you set the correct value |
+| Country (for ECC) | Automatically generates the ECC (Extended Country Code) for your radio service, associated to the selected country in the list. Select the country the radio station is broadcasting from |
+| Language (for LIC) | Automatically generates the LIC (Language Identification Code) for your radio service, associated to the selected language in the list. Select the language used by the radio station |
+| Port | The port that will be used for the "inputuri" value of your radio service. Leave the default value unless you really want to use a customized one |
 
 When clicking on the "Generate and download the odr-dabmux.info file" button, you will be prompted to edit the ```managementport```, ```telnetport```, ```zmqendpoint``` and ```listenport``` values. If you're okay to use the default values (which are pre-filled), just ignore this step and click on the "Generate and download the file now" to export your configuration.
 
-# An example...
+## An example
 
 ![example](https://github.com/user-attachments/assets/b5b1483b-cddd-4fef-b30c-4cdfaf2599b5)
 
-# Original developers
+## Original developers
 
-The original developers of ODR-DabMux are Matthias P. Braendli and Pascal Charest. Without their work, none of this would be possible.
+The original developers of ODR-DabMux are Matthias P. Braendli and
+Pascal Charest. Without their work, none of this would be possible.
 
-You can find all credits on the [original page of ODR-DabMux](https://github.com/Opendigitalradio/ODR-DabMux).
+You can find all credits on the
+[original page of ODR-DabMux](https://github.com/Opendigitalradio/ODR-DabMux).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+   name: odr-dabmux
+
+   services:
+     generator:
+       image: jitesoft/lighttpd:1.4.81
+       restart: always
+       ports:
+         - "80:80"
+       volumes:
+         - .:/var/www/html


### PR DESCRIPTION
### Changes

- README.md: fix markdown lint issues, adapt to 80-char displays and add a section for containers
- docker-compose.yml: to be used to simplify container execution